### PR TITLE
resolve the bulk update bug

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.saga-it/mirthsync "2.0.7"
+(defproject com.saga-it/mirthsync "2.0.8"
   :description "Mirthsync is a command line tool, created by Saga IT,
   for keeping a local copy of important aspects of Mirth Connect
   configuration in order to allow for the use of traditional version

--- a/src/mirthsync/actions.clj
+++ b/src/mirthsync/actions.clj
@@ -12,11 +12,11 @@
   POSTs the params to the location constructed from the base-url,
   rest-path, and id."
   [{:keys [el-loc] :as app-conf
-    {:keys [post-path push-params after-push] :as api} :api}]
-
+    {:keys [post-path push-params query-params after-push] :as api} :api}]
   (let [params (log/spyf :trace "Push params: %s" (push-params app-conf))
+        query-params (log/spyf :trace "Query params: %s" (query-params app-conf))
         result (if (post-path api)
-                 (mhttp/post-xml app-conf params)
+                 (mhttp/post-xml app-conf params query-params)
                  (mhttp/put-xml app-conf params))]
     (after-push app-conf result)))
 

--- a/src/mirthsync/apis.clj
+++ b/src/mirthsync/apis.clj
@@ -206,6 +206,7 @@
           :pre-node-action identity     ; transform app-conf before processing
           :after-push true-200          ; process result of item push
           :preprocess identity          ; preprocess app-conf before any other work
+          :query-params {}              ; query-params for HTTP POST 
           }
          api))
 
@@ -255,7 +256,8 @@
      :push-params codelib-push-params
      :preprocess (partial mact/fetch-and-pre-assoc :server-codelibs :list)
      :pre-node-action (partial pre-node-action :server-codelibs :list :codeTemplateLibrary)
-     :after-push revision-success})
+     :after-push revision-success
+     :query-params override-params})
 
    (make-api
     {:rest-path (constantly "/codeTemplates")
@@ -275,7 +277,8 @@
      :post-path post-path
      :push-params group-push-params
      :preprocess (partial mact/fetch-and-pre-assoc :server-groups :set)
-     :pre-node-action (partial pre-node-action :server-groups :set :channelGroup)})
+     :pre-node-action (partial pre-node-action :server-groups :set :channelGroup)
+     :query-params override-params})
 
    (make-api
     {:rest-path (constantly "/channels")

--- a/src/mirthsync/http_client.clj
+++ b/src/mirthsync/http_client.clj
@@ -23,9 +23,11 @@
   string."
   [{:keys [server ignore-cert-warnings]
     {:keys [post-path] :as api} :api}
-   params]
+   params
+   query-params]
   (client/post (str server (post-path api))
                {:insecure? ignore-cert-warnings
+                :query-params query-params
                 :multipart (map (fn
                                   [[k v]]
                                   {:name k


### PR DESCRIPTION
Resolve the bulk update bug where you cant update code templates libraries and channel groups

Caused by the `override` being passed in the request body and not as a query parameter.

Resolves: #8 and may also resolve #7 