### PR TITLE
build(deps-dev): bump github actions

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -15,7 +15,7 @@ jobs:
         java: [ '8', '11' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Cache downloaded Mirth servers
       uses: actions/cache@v2.0.0

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -40,7 +40,7 @@ jobs:
         java-version: ${{ matrix.java }}
 
     - name: Install clojure tools
-      uses: DeLaGuardo/setup-clojure@3.4
+      uses: DeLaGuardo/setup-clojure@4.0
       with:
         # Install just one or all simultaneously
         cli: 1.10.3.822 # Clojure CLI based on tools.deps

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Cache downloaded Mirth servers
-      uses: actions/cache@v2.0.0
+      uses: actions/cache@v3
       with:
         path: |
           vendor/mirths/mirthconnect-3.8.0.b2464-unix.tar.gz
@@ -26,7 +26,7 @@ jobs:
         key: ${{ runner.os }}-mirthconnect-3.8.0.b2464-unix.tar.gz-mirthconnect-3.9.0.b2526-unix.tar.gz-2
 
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-2

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -34,7 +34,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Setup java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt-hotspot'
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
Bump GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12.