### PR TITLE
ci: add java 17 to test matrix; update java distribution

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '8', '11', '17' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
     - name: Setup java
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt-hotspot'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
     - name: Install clojure tools


### PR DESCRIPTION
- Adds the latest LTS version of Java, v17
- Changes Java distribution used for testing from `adopt-hotspot` to Eclipse's `temurin`, AdoptOpenJDK [moved to the Eclipse project in March 2021](https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/) so all of their new releases are now under Temurin