### PR TITLE
Basic container and script for quickly generating backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:11-slim-bullseye
+RUN apt-get update && apt-get install curl -y
+RUN curl -L -O https://github.com/SagaHealthcareIT/mirthsync/releases/download/3.1.0/mirthsync-3.1.0.tar.gz\
+  && echo 'e602af6636cf139146377f98cf56331d7cb1f62fa0cdf57e8555a4a66388d420 mirthsync-3.1.0.tar.gz' | sha256sum -c
+
+RUN tar -xvzf mirthsync-3.1.0.tar.gz -C /opt\
+  && ln -s /opt/mirthsync-3.1.0/bin/mirthsync.sh /usr/local/bin/mirthsync
+
+RUN mkdir /mirth_configs

--- a/exampe_backup.sh
+++ b/exampe_backup.sh
@@ -1,0 +1,3 @@
+docker build -t mirth-backup .
+MIRTH_CMD="mirthsync -i -f -s <SERVER_NAME> -u <USERNAME> -p <PASSWORD> -t ./mirth_configs pull"
+docker run -v $(pwd)/mirth_configs:/mirth_configs mirth-backup:latest $MIRTH_CMD


### PR DESCRIPTION
We are using this to quickly allow developers to export a backup of mirth. This image can also be used to restore configs by modifying the command in the example_backup.sh

Opening a pr in case this is useful to anyone else. 