### PR TITLE
Fix --restrict-to-path with spaces and forward slashes on Windows (#82, #83)

### DIFF
--- a/pkg/mirthsync.bat
+++ b/pkg/mirthsync.bat
@@ -2,4 +2,4 @@
 SET mypath=%~dp0
 SET mypath=%mypath:~0,-1%
 
-java -jar %mypath%\..\lib\mirthsync-3.5.2-standalone.jar %*
+java -jar "%mypath%\..\lib\mirthsync-3.5.2-standalone.jar" %*

--- a/pkg/mirthsync.sh
+++ b/pkg/mirthsync.sh
@@ -13,7 +13,7 @@ if type -p greadlink; then
     _readlink=greadlink
 fi
 
-_dir=`dirname $($_readlink -f $0)`
+_dir=$(dirname "$($_readlink -f "$0")")
 
 ## mostly from - https://stackoverflow.com/a/7335524 goal is to detect
 ## java version and potentially disable access warnings
@@ -31,9 +31,9 @@ if [[ "$_java" ]]; then
     version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
     echo version "$version"
     # if [[ "$version" > "1.8" ]]; then
-    #     $_java --illegal-access=permit -jar ${_dir}/lib/uberjar/mirthsync-3.5.2-standalone.jar $@
-    # else         
-        $_java -jar ${_dir}/../lib/mirthsync-3.5.2-standalone.jar $@
+    #     "$_java" --illegal-access=permit -jar "${_dir}/lib/uberjar/mirthsync-3.5.2-standalone.jar" "$@"
+    # else
+        "$_java" -jar "${_dir}/../lib/mirthsync-3.5.2-standalone.jar" "$@"
     # fi
 fi
 ##

--- a/pkg/npm/bin/mirthsync.js
+++ b/pkg/npm/bin/mirthsync.js
@@ -139,10 +139,20 @@ function main() {
   // Build the command arguments
   const args = ['-jar', jarPath, ...process.argv.slice(2)];
 
-  // Spawn Java process with inherited stdio for full interactivity
+  // Spawn Java process with inherited stdio for full interactivity.
+  //
+  // Do NOT run this through a shell. With shell:true on Windows, Node
+  // concatenates the argv into a single command string without quoting
+  // (see Node's DEP0190 warning), so any argument containing a space —
+  // e.g. -r "Channels/Default Group/Sample Channel" — is word-split by the
+  // shell before Java ever sees it, and mirthsync fails to parse the command.
+  // Passing the argv array directly lets the runtime deliver each argument to
+  // Java verbatim, spaces and all, identically on every platform. A shell was
+  // never needed for resolution: findJava() always returns a concrete
+  // executable name ("java.exe") or absolute path, which spawn() locates on
+  // PATH on its own.
   const child = spawn(javaPath, args, {
-    stdio: 'inherit',
-    shell: process.platform === 'win32'
+    stdio: 'inherit'
   });
 
   // Forward signals to child process

--- a/pkg/npm/bin/mirthsync.js
+++ b/pkg/npm/bin/mirthsync.js
@@ -81,14 +81,16 @@ function findJava() {
   // Check if java is in PATH
   const javaCommand = process.platform === 'win32' ? 'java.exe' : 'java';
 
-  // Try running java -version to check if it's available
+  // Try running java -version to check if it's available. As with the
+  // main spawn below, do not use a shell here: it is unnecessary for a
+  // no-argument detection call, and a shell launched when java is absent
+  // can still write to stderr, which would be misread as "java present".
   const result = spawnSync(javaCommand, ['-version'], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    encoding: 'utf8',
-    shell: process.platform === 'win32'
+    encoding: 'utf8'
   });
 
-  if (result.status === 0 || result.stderr) {
+  if (!result.error && (result.status === 0 || result.stderr)) {
     // Java outputs version to stderr
     return javaCommand;
   }
@@ -102,7 +104,7 @@ function findJava() {
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf8'
       });
-      if (homeResult.status === 0 || homeResult.stderr) {
+      if (!homeResult.error && (homeResult.status === 0 || homeResult.stderr)) {
         return javaPath;
       }
     }

--- a/src/mirthsync/actions.clj
+++ b/src/mirthsync/actions.clj
@@ -214,12 +214,12 @@
   [{:keys [api] :as app-conf}]
   (let [local-path (mi/local-path api (:target app-conf))
         target-path (:target app-conf)
-        ;; Normalize paths by removing trailing slashes for comparison
-        normalized-local (if (.endsWith local-path "/")
-                           (.substring local-path 0 (dec (.length local-path)))
+        ;; Normalize paths by removing trailing separators for comparison
+        normalized-local (if (.endsWith ^String local-path File/separator)
+                           (.substring ^String local-path 0 (dec (.length ^String local-path)))
                            local-path)
-        normalized-target (if (.endsWith target-path "/")
-                            (.substring target-path 0 (dec (.length target-path)))
+        normalized-target (if (.endsWith ^String target-path File/separator)
+                            (.substring ^String target-path 0 (dec (.length ^String target-path)))
                             target-path)
         ;; For APIs that use the root target directory (like configuration-map, resources),
         ;; only capture files that match the API's file pattern instead of all files

--- a/src/mirthsync/cli.clj
+++ b/src/mirthsync/cli.clj
@@ -16,6 +16,16 @@
   (when s
     (str/replace s #"(?!^)[\\/]+$" "")))
 
+(defn- normalize-path-separators
+  "Collapses runs of forward and/or backward slashes into the platform's
+  File/separator. A restrict-to-path is matched against OS-native file paths
+  via String/startsWith (see mirthsync.xml/serialize-node and
+  mirthsync.actions/local-locs), so a path supplied with forward slashes must
+  be normalized to the platform separator to match the file paths on Windows."
+  [s]
+  (when s
+    (str/replace s #"[\\/]+" (java.util.regex.Matcher/quoteReplacement File/separator))))
+
 (def ^{:private true} cli-options
   [["-s" "--server SERVER_URL" "Full HTTP(s) url of the Mirth Connect server"
     :parse-fn strip-trailing-slashes
@@ -68,7 +78,7 @@
         that directory. The RESTRICT_TO_PATH must be specified relative to
         the target directory."
     :default ""
-    :parse-fn strip-trailing-slashes]
+    :parse-fn (comp strip-trailing-slashes normalize-path-separators)]
 
    [nil "--include-configuration-map" " A boolean flag to include the
         configuration map in a push or pull. Default: false"

--- a/test/mirthsync/apis_test.clj
+++ b/test/mirthsync/apis_test.clj
@@ -1,9 +1,11 @@
 (ns mirthsync.apis-test
   (:require [clojure.data :as cd]
             [clojure.data.zip.xml :as cdzx]
+            [clojure.java.io :as io]
             [clojure.test :as ct]
             [clojure.zip :as cz]
             [mirthsync.apis :as ma]
+            [mirthsync.cli :as cli]
             [mirthsync.interfaces]
             [mirthsync.cross-platform-utils :as cpu]
             [mirthsync.files :as mf]
@@ -266,6 +268,35 @@
       ;; When push fails, should not collect channel ID and should return false
       (ct/is (= false (mirthsync.interfaces/after-push api (assoc app-conf :el-loc el-loc) result)))
       (ct/is (empty? @(:bulk-deploy-channels app-conf))))))
+
+(ct/deftest forward-slash-restrict-to-path-pull-writes-file
+  ;; A restrict-to-path supplied with forward slashes must still match the
+  ;; OS-native file paths that serialize-node compares against via
+  ;; String/startsWith. config normalizes the separators; this drives the real
+  ;; serialize-node filter+write path end-to-end (no server) and asserts the
+  ;; file is written even when the path is given with forward slashes.
+  (let [target (build-path "target" "restrict-to-path-sep-test")
+        fpath (build-path target "Channels" "GroupA" "ChannelA.xml")
+        el-loc (mx/to-zip "<channel><id>id-1</id><name>ChannelA</name></channel>")
+        ;; restrict-to-path given with forward slashes
+        restrict-to-path (:restrict-to-path
+                          (cli/config ["-s" "https://localhost:8443/api"
+                                       "-u" "admin" "-p" "password"
+                                       "-t" target
+                                       "-r" "Channels/GroupA/ChannelA" "pull"]))
+        app-conf {:api :channels
+                  :el-loc el-loc
+                  :target target
+                  :restrict-to-path restrict-to-path
+                  :disk-mode "code"}]
+    (when (.exists (io/file target)) (cpu/delete-recursive target :allowed-dir "target"))
+    (with-redefs [mirthsync.interfaces/should-skip? (fn [_ _ _] false)
+                  mirthsync.interfaces/file-path (fn [_ _] fpath)
+                  mirthsync.interfaces/deconstruct-node (fn [_ _ _] [[fpath "<channel><id>id-1</id></channel>"]])]
+      (mx/serialize-node app-conf)
+      (ct/testing "Forward-slash restrict-to-path writes the channel file"
+        (ct/is (.exists (io/file fpath)))))
+    (when (.exists (io/file target)) (cpu/delete-recursive target :allowed-dir "target"))))
 
 (comment
   (ct/deftest iterate-apis

--- a/test/mirthsync/cli_test.clj
+++ b/test/mirthsync/cli_test.clj
@@ -131,4 +131,33 @@
       (is (seq (:exit-msg conf-no-server)))
       (is (re-find #"--server is required" (:exit-msg conf-no-server))))))
 
+(deftest restrict-to-path-separator-normalization
+  ;; A restrict-to-path supplied with forward slashes must be normalized to
+  ;; the platform File/separator so it matches OS-native file paths; on
+  ;; Windows a forward-slash prefix would otherwise never match the backslash
+  ;; file paths that the push/pull filtering compares against.
+  (let [sep java.io.File/separator
+        rtp (fn [path]
+              (:restrict-to-path
+               (config ["-s" "https://localhost:8443/api" "-u" "admin"
+                        "-p" "password" "-t" "foo" "-r" path "pull"])))]
+    (testing "Forward slashes are normalized to the platform separator"
+      (is (= (clojure.string/join sep ["Channels" "GroupA" "ChannelA"])
+             (rtp "Channels/GroupA/ChannelA"))))
+
+    (testing "Backslashes are normalized to the platform separator"
+      (is (= (clojure.string/join sep ["Channels" "GroupA" "ChannelA"])
+             (rtp "Channels\\GroupA\\ChannelA"))))
+
+    (testing "Mixed and repeated separators collapse to a single separator"
+      (is (= (clojure.string/join sep ["Channels" "GroupA" "ChannelA"])
+             (rtp "Channels//GroupA\\\\ChannelA"))))
+
+    (testing "Trailing separators are still stripped after normalization"
+      (is (= (clojure.string/join sep ["Channels" "GroupA"])
+             (rtp "Channels/GroupA/"))))
+
+    (testing "An empty restrict-to-path remains empty"
+      (is (= "" (rtp ""))))))
+
 

--- a/test/mirthsync/delete_orphaned_test.clj
+++ b/test/mirthsync/delete_orphaned_test.clj
@@ -31,7 +31,7 @@
                     :target (build-path "target" "test")}
           mock-managed-files [(io/file (build-path "target" "test" "ConfigurationMap.xml"))]
           mock-user-file (io/file (build-path "target" "test" "user-file.txt"))]
-      (with-redefs [mi/local-path (fn [_ _] (str (build-path "target" "test") "/"))  ; Root directory with trailing slash
+      (with-redefs [mi/local-path (fn [_ _] (str (build-path "target" "test") java.io.File/separator))  ; Root directory with trailing separator
                     mi/api-files (fn [_ _] mock-managed-files)]  ; Only returns managed files
         (let [result (capture-pre-pull-local-files app-conf)]
           (is (contains? (set (:pre-pull-local-files result)) (first mock-managed-files)))
@@ -47,15 +47,15 @@
         ; Root API should only capture managed files returned by mi/api-files
         (let [result (capture-pre-pull-local-files root-api-conf)]
           (is (= 1 (count (:pre-pull-local-files result))))
-          (is (= managed-files (:pre-pull-local-files result))))))))
+          (is (= managed-files (:pre-pull-local-files result)))))))
 
-  (testing "path normalization handles trailing slashes correctly"
+  (testing "path normalization handles trailing separators correctly"
     (let [app-conf {:api :resources
-                    :target (build-path "target" "test")}]  ; No trailing slash
-      (with-redefs [mi/local-path (fn [_ _] (str (build-path "target" "test") "/"))  ; With trailing slash
+                    :target (build-path "target" "test")}]  ; No trailing separator
+      (with-redefs [mi/local-path (fn [_ _] (str (build-path "target" "test") java.io.File/separator))  ; With trailing separator
                     mi/api-files (fn [_ _] [(io/file (build-path "target" "test" "Resources.xml"))])]
         (let [result (capture-pre-pull-local-files app-conf)]
-          (is (= 1 (count (:pre-pull-local-files result))))))))
+          (is (= 1 (count (:pre-pull-local-files result)))))))))
 
 (deftest cleanup-orphaned-files-with-pre-pull-test
   (testing "does not delete user files in root directory"


### PR DESCRIPTION
## Summary

Fixes two related Windows bugs with `--restrict-to-path`:

- **#82** — npm-installed `mirthsync` on Windows failed to *parse* commands when `--restrict-to-path` contained spaces (even quoted): the npm wrapper spawned Java with `shell:true` on Windows, so Node re-joined argv into one unquoted command string and the shell word-split any spaced argument before Java saw it.
- **#83** — a single-channel pull (`-r Channels/<group>/<channel>`, default `code` mode) completed with exit 0 but wrote no file on Windows. Root cause is the same separator mismatch: the forward-slash restrict path never matched the backslash file paths that the push/pull filter compares against via `String/startsWith`. (The reporter's `-m items` + `.xml` workaround was incidental — once separators are normalized, plain `startsWith` already matches `<channel>.xml`.)

## Approach

Built on @josephtelford's Windows-developed-and-tested fixes (commits `d010ef4`, `6ac4fb7`), plus two small, separately-scoped additions.

| Commit | Author | What |
|---|---|---|
| `d010ef4` | Joseph Telford | Spawn Java directly (no shell) in the npm launcher's main spawn — the #82 root cause |
| `6ac4fb7` | Joseph Telford | Normalize `-r` separators to `File/separator` so forward-slash restrict paths match on Windows — the #83 root cause; keeps the existing `startsWith` matcher |
| `74e5043` | — | Also de-shell the npm `findJava` detection + guard on `!error`; quote the jar path and `"$@"` in `mirthsync.sh`/`mirthsync.bat` for non-npm users |
| `4265248` | — | Fix `capture-pre-pull-local-files` to compare against `File/separator` instead of a hardcoded `"/"`, so Windows `--delete-orphaned` no longer captures (and risks deleting) unmanaged files like `.git` |

## On-disk format is unchanged

This deliberately does **not** touch where files are written. Separator normalization is applied to `-r` only (a pure filter — `restrict-to-path` never constructs a write path), `-t` is left as-is, and the existing `startsWith` matcher is kept. Pulled trees are byte-for-byte identical to 3.5.2 (verified by diffing full and restricted pulls).

## Testing

- Full `lein test` green locally: **41 tests, 351 assertions, 0 failures** — including the live OIE 4.5.2 integration suite.
- The base fixes (`d010ef4`, `6ac4fb7`) are already green on the `windows-latest` CI job.

Closes #82
Closes #83
