### PR TITLE
3.6.0: add -V/--version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 3.5.2
+VERSION := 3.6.0
 NPM_VERSION := $(VERSION)
 
 default:

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Options:
         When pulling from remote, compare local files with remote files and
         delete any local files that no longer exist on the remote server.
         Use with --interactive to confirm deletions before they occur.
+  -V, --version                                              Print version and exit
   -h, --help
 
 Actions:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 
 ## Current version
 
-The latest version of mirthSync is "3.5.2". Note the changes below. Version 3 of
+The latest version of mirthSync is "3.6.0". Note the changes below. Version 3 of
 mirthSync changed the layout of the target directory structure. Javascript is
 extracted into separate files and top level channels are now placed in a default
 group directory.
@@ -62,6 +62,13 @@ group directory.
 - **Security**: Path validation and safety features for file operations
 
 ## Changes
+
+### 3.6.0
+
+- **`--version` flag**: New `-V`/`--version` flag prints the installed mirthsync version and exits (no server/credentials required).
+- **Windows `--restrict-to-path` with spaces and forward slashes** (issues #82, #83): the npm launcher no longer word-splits arguments through a shell, and restrict paths supplied with forward slashes are normalized to the platform separator — so scoping a pull/push to a single channel or group (e.g. `-r "Channels/Default Group/Sample Channel"`) now works on Windows. Pulling a single channel with `-r Channels/<group>/<channel>` writes the channel file as expected.
+- **Launcher quoting**: `mirthsync.sh`/`mirthsync.bat` quote the jar path and arguments so install paths or arguments containing spaces are handled correctly.
+- **Windows `--delete-orphaned` fix**: orphan detection no longer captures unmanaged files (e.g. `.git`) under the target root on Windows, preventing accidental deletion.
 
 ### 3.5.2
 

--- a/pkg/mirthsync.bat
+++ b/pkg/mirthsync.bat
@@ -2,4 +2,4 @@
 SET mypath=%~dp0
 SET mypath=%mypath:~0,-1%
 
-java -jar "%mypath%\..\lib\mirthsync-3.5.2-standalone.jar" %*
+java -jar "%mypath%\..\lib\mirthsync-3.6.0-standalone.jar" %*

--- a/pkg/mirthsync.sh
+++ b/pkg/mirthsync.sh
@@ -31,9 +31,9 @@ if [[ "$_java" ]]; then
     version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
     echo version "$version"
     # if [[ "$version" > "1.8" ]]; then
-    #     "$_java" --illegal-access=permit -jar "${_dir}/lib/uberjar/mirthsync-3.5.2-standalone.jar" "$@"
+    #     "$_java" --illegal-access=permit -jar "${_dir}/lib/uberjar/mirthsync-3.6.0-standalone.jar" "$@"
     # else
-        "$_java" -jar "${_dir}/../lib/mirthsync-3.5.2-standalone.jar" "$@"
+        "$_java" -jar "${_dir}/../lib/mirthsync-3.6.0-standalone.jar" "$@"
     # fi
 fi
 ##

--- a/pkg/npm/package.json
+++ b/pkg/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saga-it/mirthsync",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "DevOps tool for Mirth Connect and Open Integration Engine version control and CI/CD automation",
   "keywords": [
     "mirth",

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.saga-it/mirthsync "3.5.2"
+(defproject com.saga-it/mirthsync "3.6.0"
   :description "MirthSync is an open source DevOps tool for Mirth Connect and
   Open Integration Engine version control and CI/CD automation. This command line
   tool enables healthcare integration DevOps workflows by keeping a local copy of

--- a/src/mirthsync/cli.clj
+++ b/src/mirthsync/cli.clj
@@ -5,6 +5,7 @@
             [clojure.string :as str]
             [clojure.java.io :as io]
             [mirthsync.logging :as log]
+            [mirthsync.version :as ver]
             [environ.core :refer [env]])
   (:import java.net.URL
            java.io.File))
@@ -119,6 +120,8 @@
         delete any local files that no longer exist on the remote server.
         Use with --interactive to confirm deletions before they occur."
     :default false]
+
+   ["-V" "--version" "Print version and exit"]
 
    ["-h" "--help"]])
 
@@ -253,18 +256,22 @@
                        (assoc % :git-subcommand-args git-args)
                        %))
                    
-                   ;; Set up our exit code
+                   ;; Set up our exit code. --version short-circuits cleanly
+                   ;; (like --help) without requiring --target/--server/auth.
                    (assoc :exit-code
-                          (if (or (:errors config)
-                                  (not args-valid?))
+                          (if (and (not (get-in config [:options :version]))
+                                   (or (:errors config)
+                                       (not args-valid?)))
                             1
                             0)))
 
         config (-> config
                    ;; exit message if errors - add custom validation errors
                    (assoc :exit-msg
-                          (when (or (> (:exit-code config) 0)
-                                    (:help config))
+                          (cond
+                            (:version config) ver/version
+                            (or (> (:exit-code config) 0)
+                                (:help config))
                             (let [action (first (:arguments config))
                                   git-action? (= "git" action)
                                   has-username? (:username config)

--- a/src/mirthsync/version.clj
+++ b/src/mirthsync/version.clj
@@ -1,0 +1,24 @@
+(ns mirthsync.version
+  "Exposes the mirthsync version as a single source of truth. The value is
+  read from the uberjar's own MANIFEST.MF (where Leiningen records
+  Leiningen-Project-Version from project.clj), so it can never drift from
+  the released artifact. When running from source (e.g. 'lein run') there
+  is no such manifest and the version reports as \"dev\"."
+  (:import [java.util.jar Manifest]
+           [java.net URL]))
+
+(defn- read-version
+  "Returns Leiningen-Project-Version from the manifest whose Main-Class is
+  mirthsync.core, or nil when no such manifest is on the classpath."
+  []
+  (let [^ClassLoader cl (.getContextClassLoader (Thread/currentThread))]
+    (some (fn [^URL url]
+            (with-open [is (.openStream url)]
+              (let [attrs (.getMainAttributes (Manifest. is))]
+                (when (= "mirthsync.core" (.getValue attrs "Main-Class"))
+                  (.getValue attrs "Leiningen-Project-Version")))))
+          (enumeration-seq (.getResources cl "META-INF/MANIFEST.MF")))))
+
+(def ^String version
+  "The mirthsync version string (e.g. \"3.6.0\"), or \"dev\" when run from source."
+  (or (read-version) "dev"))

--- a/test/mirthsync/cli_test.clj
+++ b/test/mirthsync/cli_test.clj
@@ -1,8 +1,22 @@
 (ns mirthsync.cli-test
   (:require [mirthsync.cli :refer :all]
+            [mirthsync.version :as ver]
             [clojure.test :refer :all]
             [clojure.tools
              [cli :refer [parse-opts]]]))
+
+(deftest version-flag
+  ;; --version short-circuits like --help: it prints the version and exits 0
+  ;; without requiring --target/--server/authentication. Assert against the
+  ;; version namespace value (not a literal) so it survives version bumps.
+  (testing "--version yields exit 0 and the version string, no other args needed"
+    (let [conf (config ["--version"])]
+      (is (= 0 (:exit-code conf)))
+      (is (= ver/version (:exit-msg conf)))))
+  (testing "-V short alias behaves the same"
+    (let [conf (config ["-V"])]
+      (is (= 0 (:exit-code conf)))
+      (is (= ver/version (:exit-msg conf))))))
 
 (deftest configuration
   (testing "Fail on invalid arguments"


### PR DESCRIPTION
## Summary
Completes the **mirthsync 3.6.0** release. Adds a `-V`/`--version` CLI flag and bumps the project version to 3.6.0. The Windows `--restrict-to-path` (#82) / single-channel (#83) / `--delete-orphaned` fixes already landed via #84; this PR is the version flag + the coordinated version bump.

## Changes
- **New `-V`/`--version` flag** — prints the bare version and exits 0 (no `--target`/`--server`/auth required, like `--help`). The version is read from the uberjar `MANIFEST` (`Leiningen-Project-Version`) via a new `mirthsync.version` namespace — single source of truth; falls back to `dev` when run from source.
- **Version → 3.6.0** in `project.clj`, `Makefile`, `README.md` (version line, changelog, CLI help block), `pkg/mirthsync.sh`, `pkg/mirthsync.bat`, `pkg/npm/package.json`.
- Unit test for the flag in `test/mirthsync/cli_test.clj`.

## Notes
- **No on-disk format change** — no path/separator/restrict/write-placement logic is touched, so users' files stay at the same paths on next pull.