### PR TITLE
release: pin the GPG signing key for archive .asc files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,11 @@ release:
 	cp target/uberjar/mirthsync-$(VERSION)-standalone.jar target/mirthsync-$(VERSION)/lib
 	tar -C target/ -cvzf target/mirthsync-$(VERSION).tar.gz mirthsync-$(VERSION)
 	cd target && zip -r mirthsync-$(VERSION).zip mirthsync-$(VERSION)
-	gpg --detach-sign --armor target/mirthsync-$(VERSION).tar.gz
-	gpg --detach-sign --armor target/mirthsync-$(VERSION).zip
+# Sign the release archives with the release key explicitly. The keyring may
+# hold more than one secret key, so -u avoids gpg's default-key selection
+# (matches the :signing :gpg-key in project.clj and the signed git tag).
+	gpg -u jesse.dowell@gmail.com --detach-sign --armor target/mirthsync-$(VERSION).tar.gz
+	gpg -u jesse.dowell@gmail.com --detach-sign --armor target/mirthsync-$(VERSION).zip
 	cd target && sha256sum mirthsync-$(VERSION).tar.gz mirthsync-$(VERSION).zip > CHECKSUMS.txt
 	lein do vcs assert-committed, vcs tag
 


### PR DESCRIPTION
## Summary
`make release` signs the distribution archives with `gpg --detach-sign --armor` **without `-u`**, so it uses gpg's *default* secret key. A second secret key (`Saga IT LLC <admin@saga-it.com>`) is now in the keyring and no `default-key` is configured, so the default resolves to the **wrong key** — the `mirthsync-3.6.0.tar.gz.asc` / `.zip.asc` signatures would **not** match the signed git tag (pinned via `user.signingkey`) or the `.asc` files on the 3.5.1/3.5.2 releases.

## Fix
Pin `-u jesse.dowell@gmail.com` on the two `gpg --detach-sign` lines — the same key as `project.clj`'s `:signing {:gpg-key ...}` and the release git tag. Now the archive signatures are reproducible and consistent regardless of keyring order on the release machine.

No functional/code change; build tooling only. Verified `-u jesse.dowell@gmail.com` resolves to `BAD6…CCB5` (the historical release key).